### PR TITLE
Fix: Align feature card layout with icon, title, and description

### DIFF
--- a/src/components/ui/card-hover-effect.tsx
+++ b/src/components/ui/card-hover-effect.tsx
@@ -50,11 +50,13 @@ export const HoverEffect = ({
 
           {/* Card Content with Icon */}
           <Card>
-            <div className="flex items-center gap-3">
+            <div className="flex flex-col items-start space-y-4">
+            <div className="flex items-center gap-2">
               <span className="text-white">{item.icon}</span>
               <CardTitle>{item.title}</CardTitle>
             </div>
             <CardDescription>{item.description}</CardDescription>
+            </div>
           </Card>
         </div>
       ))}
@@ -91,7 +93,7 @@ export const CardTitle = ({
   children: React.ReactNode;
 }) => {
   return (
-    <h4 className={cn("text-zinc-100 font-bold tracking-wide mt-4", className)}>
+    <h4 className={cn("text-zinc-100 font-bold tracking-wide", className)}>
       {children}
     </h4>
   );
@@ -107,7 +109,7 @@ export const CardDescription = ({
   return (
     <p
       className={cn(
-        "mt-4 text-zinc-400 tracking-wide leading-relaxed text-sm",
+        "mt-4 text-zinc-400 tracking-wide leading-relaxed text-sm text-left",
         className
       )}
     >


### PR DESCRIPTION
-> Aligned icon and title on the same row using flex.
-> Aligned description directly below icon/title group.
-> Changed description text alignment from center to left for readability.

**Before the fixing**
![Screenshot 2025-05-14 000639](https://github.com/user-attachments/assets/24ab46f1-2e7e-4903-a6d0-eb4ae626b01b)
**After the fix**
![Screenshot 2025-05-14 194445](https://github.com/user-attachments/assets/3ac6c4f9-2e37-4bcc-b656-b61ee4ca4b33)

> Closing the issue #1 